### PR TITLE
feat(ci): add GitHub official runner image alongside summerwind

### DIFF
--- a/.github/workflows/image-build-new.yaml
+++ b/.github/workflows/image-build-new.yaml
@@ -1,0 +1,66 @@
+name: image-build-new
+on:
+  push:
+    branches:
+      - "main"
+    paths:
+      - "Dockerfile.new"
+      - ".github/workflows/image-build-new.yaml"
+      - "!**.md"
+  pull_request:
+    branches:
+      - "main"
+    paths:
+      - "Dockerfile.new"
+      - ".github/workflows/image-build-new.yaml"
+      - "!**.md"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v7
+        timeout-minutes: 1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+        timeout-minutes: 5
+
+      - name: Authenticate to GCP
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: google-github-actions/auth@v3
+        timeout-minutes: 1
+        with:
+          credentials_json: ${{ secrets.GOOGLE_ARTIFACT_REGISTRY_SA_KEY }}
+
+      - name: Login to GAR
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: docker/login-action@v4
+        timeout-minutes: 1
+        with:
+          registry: ${{ secrets.GOOGLE_ARTIFACT_REGISTRY_LOGIN_SERVER }}
+          username: _json_key
+          password: ${{ secrets.GOOGLE_ARTIFACT_REGISTRY_SA_KEY }}
+
+      - name: Docker Meta
+        id: meta
+        uses: docker/metadata-action@v6
+        timeout-minutes: 1
+        with:
+          images: ${{ secrets.GOOGLE_ARTIFACT_REGISTRY_LOGIN_SERVER }}/cognyx-471812/ghar-image
+          tags: |
+            type=raw,value=new-runner
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v7
+        timeout-minutes: 10
+        with:
+          context: .
+          file: Dockerfile.new
+          cache-from: type=gha,scope=new-runner
+          cache-to: type=gha,mode=max,scope=new-runner
+          push: ${{ github.ref_name == 'main' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}

--- a/Dockerfile.new
+++ b/Dockerfile.new
@@ -1,0 +1,53 @@
+FROM docker.io/library/golang:1.26.4 AS golang
+
+FROM ghcr.io/actions/actions-runner:2.336.0
+
+USER root
+COPY --from=golang "/usr/local/go/" "/usr/local/go/"
+ENV PATH="/usr/local/go/bin:${PATH}"
+ENV PLAYWRIGHT_BROWSERS_PATH="/ms-playwright"
+
+RUN set -ex; \
+  export DEBIAN_FRONTEND=noninteractive; \
+  # Setup Node.js repository
+  curl -fsSL https://deb.nodesource.com/setup_24.x | bash -; \
+  \
+  # Add GitHub CLI repository
+  curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg; \
+  chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg; \
+  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
+  \
+  # Update and install all packages
+  apt-get update; \
+  apt-get install --no-install-recommends --no-install-suggests -y \
+  gh \
+  nodejs \
+  git unzip libpq-dev build-essential libvips-dev pkg-config; \
+  \
+  # Setup Node packages
+  npm install -g pnpm wrangler@3.56.0 firebase-tools; \
+  \
+  # Install Kubernetes tools
+  echo "Installing kubectl..."; \
+  curl -fsSLO "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"; \
+  install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl; \
+  rm kubectl; \
+  \
+  echo "Installing Helm..."; \
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash; \
+  \
+  echo "Installing Playwright and Chromium dependencies..."; \
+  npm install -g playwright@1.58.2; \
+  npx playwright install --with-deps chromium; \
+  chmod -R 777 $PLAYWRIGHT_BROWSERS_PATH; \
+  npm cache clean --force; \
+  mkdir -p /home/runner/.npm /home/runner/.cache; \
+  chown -R 1001:1001 /home/runner/.npm /home/runner/.cache || true; \
+  \
+  # Cleanup apt caches aggressively
+  apt-get clean autoclean; \
+  apt-get autoremove --yes; \
+  rm -rf /var/lib/apt/lists/*
+
+USER runner
+RUN echo "PATH=$PATH" >> /home/runner/.env

--- a/README.md
+++ b/README.md
@@ -1,15 +1,36 @@
 # GHAR (DinD) runner image
 
-D-in-D image for GitHub Actions Self-Hoster runner based on [summerwind/actions-runner-dind](https://hub.docker.com/r/summerwind/actions-runner-dind)
+Custom GitHub Actions Self-Hosted runner images for CI/CD workflows.
+
+## Dockerfile Versions
+
+| File | Base Image | Status |
+|------|------------|--------|
+| `Dockerfile` | `summerwind/actions-runner-dind:v2.335.1-ubuntu-24.04` | Current (production) |
+| `Dockerfile.new` | `ghcr.io/actions/actions-runner:2.336.0` | `new-runner` tag (testing) |
+
+## Migration
+
+To test the new image:
+
+```bash
+# Build from the new Dockerfile
+docker buildx build -t ghar-image:test -f Dockerfile.new .
+
+# Test the image
+docker run -it --entrypoint=bash --rm ghar-image:test
+
+# Once validated, replace the original Dockerfile
+mv Dockerfile.new Dockerfile
+```
 
 ## Packages
 
 | Package                                | Version     | Version CLI                |
 | -------------------------------------- | ----------- | -------------------------- |
 | **Ubuntu (Base OS)**                   | `24.04 LTS` | `cat /etc/os-release`      |
-| **GitHub Actions Runner (summerwind)** | `2.335.1`   | `/runner/run.sh --version` |
-| **Golang**                             | `1.25.3`    | `go version`               |
-| **Buildx**                             | `0.35.0`    | `docker buildx version`    |
+| **GitHub Actions Runner**              | `2.335.1`/`2.336.0` | `/home/runner/run.sh --version` |
+| **Golang**                             | `1.26.4`    | `go version`               |
 | **Node.js**                            | `24.x`      | `node --version`           |
 | **npm**                                | `11.6.2`    | `npm --version`            |
 | **pnpm**                               | `10.33.0`   | `pnpm --version`           |
@@ -24,8 +45,29 @@ D-in-D image for GitHub Actions Self-Hoster runner based on [summerwind/actions-
 
 ## Run
 
-`docker run -it --entrypoint=bash --rm eu.gcr.io/cognyx-471812/ghar-image:latest`
+```bash
+# Current (summerwind)
+docker run -it --entrypoint=bash --rm eu.gcr.io/cognyx-471812/ghar-image:latest
+
+# Test (official runner)
+docker run -it --entrypoint=bash --rm ghar-image:new-runner
+```
 
 ## Build
 
-- `docker buildx build -t ghar-image .`
+```bash
+# Build current
+docker buildx build -t ghar-image .
+
+# Build new (for testing)
+docker buildx build -t ghar-image:new-runner -f Dockerfile.new .
+```
+
+## Key Differences: summerwind vs official runner
+
+| Feature | summerwind | official runner |
+|---------|------------|-----------------|
+| DinD | Built-in | Sidecar container (infra) |
+| PATH env file | `/runnertmp/.env` | `/home/runner/.env` |
+| Custom flags | `sed` modification | Native support |
+| Buildx | Bundled binary | Handled by infra |


### PR DESCRIPTION
## Summary

Migrates from summerwind/actions-runner-dind to the official GitHub Actions runner image (ghcr.io/actions/actions-runner). This PR adds the new image alongside the existing one for safe testing before full cutover.

**Related:** TEC-5163

### Changes

| File | Description |
|------|-------------|
| `Dockerfile.new` | New runner image based on `ghcr.io/actions/actions-runner:2.336.0` |
| `.github/workflows/image-build-new.yaml` | Separate CI workflow to build the new image (tag: `new-runner`) |
| `README.md` | Updated with migration guide and both image versions |

### What Changed

**Removed (summerwind-specific):**
- `buildx` stage and binary copy (handled via sidecar on infra)
- `sed` command modifying `startup.sh` for custom registration flags
- DinD built-in support (now handled via sidecar container on infrastructure side)

**Updated:**
- Base image: `summerwind/actions-runner-dind:v2.335.1-ubuntu-24.04` → `ghcr.io/actions/actions-runner:2.336.0`
- PATH persistence: `/runnertmp/.env` → `/home/runner/.env`

### Image Tags

| Image | Tag | Description |
|-------|-----|-------------|
| Current | `latest` | summerwind-based (production) |
| New | `new-runner` | Official runner (testing) |

## Test Plan

- [ ] Build new image locally: `docker buildx build -t ghar-image:new-runner -f Dockerfile.new .`
- [ ] Test the new image in a CI workflow
- [ ] Verify all tools work (Node.js, Playwright, kubectl, Helm, pnpm, wrangler, firebase-tools)
- [ ] Validate DinD functionality via sidecar container
- [ ] Once validated, replace `Dockerfile` with `Dockerfile.new`

## Migration Path

1. This PR adds the new image alongside the existing one
2. Test `ghar-image:new-runner` in your CIs
3. Once validated, create a follow-up PR to replace `Dockerfile` with `Dockerfile.new`